### PR TITLE
Replaced old repo name with the new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Ensure you have the following installed on your local machine:
 1. Clone the repository:
 
    ```sh
-   git clone https://github.com/sailingsam/house_arena_react-vite.git
+   git clone https://github.com/sailingsam/House-Arena_frontend.git
    ```
 
 2. Navigate to the project directory:
@@ -77,7 +77,7 @@ The backend for this project is built using Express, Node.js, and MongoDB. You c
 
 All code contributions must go through a pull request and be approved by a core developer before being merged. This is to ensure a proper review of all the code.
 
-We truly ❤️ pull requests! If you wish to help, you can learn more about how you can contribute to this project in the [**contribution guide**](https://github.com/sailingsam/house_arena_react-vite/blob/main/CONTRIBUTING.md).
+We truly ❤️ pull requests! If you wish to help, you can learn more about how you can contribute to this project in the [**contribution guide**](https://github.com/sailingsam/House-Arena_frontend/blob/main/CONTRIBUTING.md).
 
 ## Contact
 

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -14,7 +14,7 @@ function Footer() {
       label: "Resources",
       items: [
         {
-          href: "https://github.com/sailingsam/house_arena_react-vite",
+          href: "https://github.com/sailingsam/House-Arena_frontend",
           name: "Github",
         },
       ],

--- a/src/Components/NavHeader/Navheader.jsx
+++ b/src/Components/NavHeader/Navheader.jsx
@@ -75,7 +75,7 @@ function Navheader() {
               <li className="mt-8 mb-8 lg:mt-0 lg:mb-0">
                 <Tooltip title="Contribute on Github">
                   <a
-                    href="https://github.com/sailingsam/house_arena_react-vite"
+                    href="https://github.com/sailingsam/House-Arena_frontend"
                     target="_blank"
                   >
                     <svg

--- a/src/Components/upcomingFeature/LaunchSoon.jsx
+++ b/src/Components/upcomingFeature/LaunchSoon.jsx
@@ -17,7 +17,7 @@ export default () => {
               We are working hard to bring you the best experience possible.
             </p>
             <NavLink
-              to="https://github.com/sailingsam/house_arena_react-vite  "
+              to="https://github.com/sailingsam/House-Arena_frontend  "
               className="block py-2 px-3 ml-2 text-white font-medium bg-indigo-600 duration-150 hover:bg-indigo-500 active:bg-indigo-700 rounded-3xl shadow-lg hover:shadow-none"
             >
               Contribute

--- a/src/Pages/HomePage/HeroMainpage/Herosection.jsx
+++ b/src/Pages/HomePage/HeroMainpage/Herosection.jsx
@@ -32,7 +32,7 @@ export default () => {
               </div>
             </button>
           </NavLink>
-          <a href={"https://github.com/sailingsam/house_arena_react-vite"} target="_blank">
+          <a href={"https://github.com/sailingsam/House-Arena_frontend"} target="_blank">
             <button class="text-zinc-400 hover:text-purple-600 backdrop-blur-lg bg-gradient-to-tr from-transparent via-[rgba(121,121,121,0.16)] to-transparent rounded-md py-2 px-6 shadow hover:shadow-purple-600 duration-700">
               Contribute
             </button>


### PR DESCRIPTION
## What does this PR do?

Replaced old repo name with the new name (House-Arena_frontend)

Found changes in below files: 
![image](https://github.com/user-attachments/assets/05bb9d63-49f9-478c-a3c2-7237d485a2e0)
